### PR TITLE
sopc2dts patch-up: create image based on cdsteinkuehler/jessie-quartu…

### DIFF
--- a/Jessie-Quartus-15.1.2-sopc2dts/Dockerfile
+++ b/Jessie-Quartus-15.1.2-sopc2dts/Dockerfile
@@ -1,0 +1,17 @@
+FROM cdsteinkuehler/jessie-quartus-15.1.2
+MAINTAINER Michael Haberler <haberlerm@gmail.com>
+
+RUN apt-get update && \
+    apt-get -y install \
+	openjdk-7-jdk && \
+    git clone --depth 1 https://github.com/altera-opensource/sopc2dts && \
+    make -C sopc2dts && \
+    mkdir -p /usr/local/share/sopc2dts && \
+    cp sopc2dts/sopc2dts.jar /usr/local/share/sopc2dts && \
+    /bin/echo -e '#!/bin/bash -e\njava -jar /usr/local/share/sopc2dts/sopc2dts.jar $*\n' > /usr/local/bin/sopc2dts && \
+    chmod +x /usr/local/bin/sopc2dts && \
+    rm -rf sopc2dts
+
+
+# Add Quartus bin directorys to the path
+ENV PATH $PATH:/root/altera_lite/15.1/quartus/bin:/root/altera_lite/15.1/quartus/sopc_builder/bin


### PR DESCRIPTION
…s-15.1.2

this should be rolled into your main image

I'm running this in jenkins on mah.priv.at until we have a new image:

 # work with patched-up image until a new one is rolled
docker run -i -v $(pwd):/work mhaberler/jessie-quartus-15.1.2-sopc2dts  /work/Scripts/travis_build.sh
