### PR TITLE
base: add pkg-config

### DIFF
--- a/Jessie-Quartus-Base/Dockerfile
+++ b/Jessie-Quartus-Base/Dockerfile
@@ -24,6 +24,7 @@ RUN echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > \
         make \
         xauth \
         xvfb \
+	pkg-config \
 	libprotobuf-dev \
 	protobuf-compiler \
 	python-protobuf \


### PR DESCRIPTION
the machinetalk-protobuf Makefile needs this

now the protobuf encoding in the mksocfpga job works: https://jenkins.machinekit.io/view/machinekit/job/mksocfpga/75/console

(already rebuilt container with pkg-config)
